### PR TITLE
[Feat] : Security 설정 클래스 생성 (가장 기본으로, `/auth/**` URI만 통과토록)

### DIFF
--- a/src/main/java/com/sctk/cmc/config/SecurityConfig.java
+++ b/src/main/java/com/sctk/cmc/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.sctk.cmc.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable() // REST API 서버이므로 csrf 보안 필요 X
+                .httpBasic().disable() // API 통신을 통한 로그인을 이용할 것으로, http 기반 로그인 X
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 인증 정보 저장 X
+                .and()
+                .authorizeRequests()
+                .antMatchers("/auth/**").permitAll()
+                .anyRequest()
+                .authenticated();
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- SecurityConfig.java
```java
@Configuration
public class SecurityConfig {
    @Bean
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .csrf().disable() // REST API 서버이므로 csrf 보안 필요 X
                .httpBasic().disable() // API 통신을 통한 로그인을 이용할 것으로, http 기반 로그인 X
                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 인증 정보 저장 X
                .and()
                .authorizeRequests()
                .antMatchers("/auth/**").permitAll()
                .anyRequest()
                .authenticated();

        return http.build();
    }
}
```
@lcj1204 
Security 가장 기본적인 설정만을 해두었습니다. (폼 로그인 X, `/auth/**` URI는 인증 없이 통과)
JWT 이용하여 구현하고자 할 때, 많은 설정할 것들이 존재하는데, 구현하실 때 같이 이야기하면서 해야할 듯 해서 이렇게만 해두었습니다!!

**같이 이야기할 것들**
- 로그인 방식 
  - email & pwd 로?

- JWT 발급 방식
  - Access Token과 Refresh Token을 둘 다 한번에 발급?