### PR TITLE
[Refactor] exception 과 response 관리하는 common 패키지

### DIFF
--- a/src/main/java/com/sctk/cmc/common/exception/CMCException.java
+++ b/src/main/java/com/sctk/cmc/common/exception/CMCException.java
@@ -1,4 +1,4 @@
-package com.sctk.cmc.exception;
+package com.sctk.cmc.common.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/com/sctk/cmc/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sctk/cmc/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.sctk.cmc.common.exception;
+
+import com.sctk.cmc.common.response.BaseResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CMCException.class)
+    public ResponseEntity<Object> handleCMCException(CMCException e) {
+        ResponseStatus status = e.getStatus();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new BaseResponse<>(status));
+    }
+}

--- a/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
+++ b/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
@@ -1,5 +1,8 @@
-package com.sctk.cmc.exception;
+package com.sctk.cmc.common.exception;
 
+import lombok.Getter;
+
+@Getter
 public enum ResponseStatus {
     // Common
     SUCCESS(1000, "응답에 성공하였습니다."),

--- a/src/main/java/com/sctk/cmc/common/response/BaseResponse.java
+++ b/src/main/java/com/sctk/cmc/common/response/BaseResponse.java
@@ -1,0 +1,34 @@
+package com.sctk.cmc.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sctk.cmc.common.exception.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BaseResponse<T> {
+
+    private static final int SUCCESS_CODE = 1000;
+    private static final String SUCCESS_MESSAGE = "요청에 성공하였습니다.";
+
+    private final Boolean isSuccess;
+    private final int code;
+    private final String message;
+
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private T data;
+
+    // 성공시 반환되는 Response
+    public BaseResponse(T data) {
+        this.isSuccess = true;
+        this.code = SUCCESS_CODE;
+        this.message = SUCCESS_MESSAGE;
+        this.data = data;
+    }
+
+    // 실패시 반환되는 Response
+    public BaseResponse(ResponseStatus status) {
+        this.isSuccess = false;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+    }
+}

--- a/src/main/java/com/sctk/cmc/domain/Designer.java
+++ b/src/main/java/com/sctk/cmc/domain/Designer.java
@@ -1,7 +1,6 @@
 package com.sctk.cmc.domain;
 
-import com.sctk.cmc.exception.CMCException;
-import com.sctk.cmc.exception.ResponseStatus;
+import com.sctk.cmc.common.exception.CMCException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +9,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.sctk.cmc.exception.ResponseStatus.*;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/sctk/cmc/service/AuthServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/AuthServiceImpl.java
@@ -2,7 +2,7 @@ package com.sctk.cmc.service;
 
 import com.sctk.cmc.domain.Designer;
 import com.sctk.cmc.domain.Member;
-import com.sctk.cmc.exception.CMCException;
+import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.service.abstractions.AuthService;
 import com.sctk.cmc.service.abstractions.DesignerService;
 import com.sctk.cmc.service.abstractions.MemberService;
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import static com.sctk.cmc.exception.ResponseStatus.*;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/sctk/cmc/service/DesignerServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/DesignerServiceImpl.java
@@ -4,7 +4,7 @@ import com.sctk.cmc.domain.Designer;
 import com.sctk.cmc.domain.HighCategory;
 import com.sctk.cmc.domain.LowCategory;
 import com.sctk.cmc.dto.designer.DesignerJoinParam;
-import com.sctk.cmc.exception.CMCException;
+import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.repository.DesignerRepository;
 import com.sctk.cmc.service.abstractions.DesignerService;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.sctk.cmc.exception.ResponseStatus.AUTHENTICATION_ILLEGAL_EMAIL;
-import static com.sctk.cmc.exception.ResponseStatus.DESIGNERS_ILLEGAL_ID;
+import static com.sctk.cmc.common.exception.ResponseStatus.AUTHENTICATION_ILLEGAL_EMAIL;
+import static com.sctk.cmc.common.exception.ResponseStatus.DESIGNERS_ILLEGAL_ID;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/sctk/cmc/service/MemberServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/MemberServiceImpl.java
@@ -2,7 +2,7 @@ package com.sctk.cmc.service;
 
 import com.sctk.cmc.domain.Member;
 import com.sctk.cmc.dto.member.MemberJoinParam;
-import com.sctk.cmc.exception.CMCException;
+import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.repository.MemberRepository;
 import com.sctk.cmc.service.abstractions.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.sctk.cmc.exception.ResponseStatus.*;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 
 @RequiredArgsConstructor
 @Service

--- a/src/test/java/com/sctk/cmc/service/AuthServiceImplTest.java
+++ b/src/test/java/com/sctk/cmc/service/AuthServiceImplTest.java
@@ -2,7 +2,7 @@ package com.sctk.cmc.service;
 
 import com.sctk.cmc.domain.Designer;
 import com.sctk.cmc.domain.Member;
-import com.sctk.cmc.exception.CMCException;
+import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.service.abstractions.AuthService;
 import com.sctk.cmc.service.abstractions.DesignerService;
 import com.sctk.cmc.service.abstractions.MemberService;
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static com.sctk.cmc.exception.ResponseStatus.*;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/sctk/cmc/service/DesignerServiceImplTest.java
+++ b/src/test/java/com/sctk/cmc/service/DesignerServiceImplTest.java
@@ -4,7 +4,7 @@ import com.sctk.cmc.domain.Designer;
 import com.sctk.cmc.domain.HighCategory;
 import com.sctk.cmc.domain.LowCategory;
 import com.sctk.cmc.dto.designer.DesignerJoinParam;
-import com.sctk.cmc.exception.CMCException;
+import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.repository.DesignerRepository;
 import com.sctk.cmc.service.abstractions.DesignerService;
 import org.junit.jupiter.api.Test;
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.sctk.cmc.exception.ResponseStatus.*;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;

--- a/src/test/java/com/sctk/cmc/service/MemberServiceImplTest.java
+++ b/src/test/java/com/sctk/cmc/service/MemberServiceImplTest.java
@@ -2,7 +2,7 @@ package com.sctk.cmc.service;
 
 import com.sctk.cmc.domain.Member;
 import com.sctk.cmc.dto.member.MemberJoinParam;
-import com.sctk.cmc.exception.CMCException;
+import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.repository.MemberRepository;
 import com.sctk.cmc.service.abstractions.MemberService;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
 
-import static com.sctk.cmc.exception.ResponseStatus.*;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- `exception` 패키지와 `response` 패키지를 `common` 패키지로 묶음
- 성공 및 실패 시 기본 `Response` 클래스 구현
- `ExceptionHandler` 구현

### :: 특이사항
- `ExceptionHandler` 에서 `HttpStatus`는 우선 `BAD_REQUEST` 로 적용. 예외들 마다 HttpStatus 를 어떻게 둘지 논의 필요.
