### PR TITLE
[Feat] Spring Security와 JWT 및 Redis 설정 구현

### DIFF
--- a/src/main/java/com/sctk/cmc/auth/domain/SecurityDesignerDetails.java
+++ b/src/main/java/com/sctk/cmc/auth/domain/SecurityDesignerDetails.java
@@ -1,0 +1,57 @@
+package com.sctk.cmc.auth.domain;
+
+import com.sctk.cmc.domain.Designer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class SecurityDesignerDetails implements UserDetails {
+
+    private final Designer designer;
+
+    public Long getId() {
+        return designer.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ArrayList<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(designer.getRole().getRoleName()));
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return designer.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/sctk/cmc/auth/domain/SecurityMemberDetails.java
+++ b/src/main/java/com/sctk/cmc/auth/domain/SecurityMemberDetails.java
@@ -1,0 +1,57 @@
+package com.sctk.cmc.auth.domain;
+
+import com.sctk.cmc.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class SecurityMemberDetails implements UserDetails {
+
+    private final Member member;
+
+    public Long getId() {
+        return member.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ArrayList<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().getRoleName()));
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/sctk/cmc/auth/domain/Token.java
+++ b/src/main/java/com/sctk/cmc/auth/domain/Token.java
@@ -1,0 +1,11 @@
+package com.sctk.cmc.auth.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Token {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/sctk/cmc/auth/dto/CommonUser.java
+++ b/src/main/java/com/sctk/cmc/auth/dto/CommonUser.java
@@ -1,0 +1,11 @@
+package com.sctk.cmc.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommonUser {
+    private String role;
+    private String email;
+}

--- a/src/main/java/com/sctk/cmc/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/sctk/cmc/auth/dto/LoginResponseDto.java
@@ -1,0 +1,21 @@
+package com.sctk.cmc.auth.dto;
+
+import com.sctk.cmc.auth.domain.Token;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDto {
+    private Long Id;
+    private String accessToken;
+    private String refreshToken;
+
+    public static LoginResponseDto of(Long id, Token token) {
+        return LoginResponseDto.builder()
+                .Id(id)
+                .accessToken(token.getAccessToken())
+                .refreshToken(token.getRefreshToken())
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/auth/dto/TokenReissueRequestDto.java
+++ b/src/main/java/com/sctk/cmc/auth/dto/TokenReissueRequestDto.java
@@ -1,0 +1,9 @@
+package com.sctk.cmc.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequestDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/sctk/cmc/auth/dto/TokenReissueResponseDto.java
+++ b/src/main/java/com/sctk/cmc/auth/dto/TokenReissueResponseDto.java
@@ -1,0 +1,19 @@
+package com.sctk.cmc.auth.dto;
+
+import com.sctk.cmc.auth.domain.Token;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenReissueResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    public static TokenReissueResponseDto of( Token token ) {
+        return TokenReissueResponseDto.builder()
+                .accessToken( token.getAccessToken() )
+                .refreshToken( token.getRefreshToken() )
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/auth/filter/JwtFilter.java
+++ b/src/main/java/com/sctk/cmc/auth/filter/JwtFilter.java
@@ -1,0 +1,50 @@
+package com.sctk.cmc.auth.filter;
+
+import com.sctk.cmc.auth.dto.CommonUser;
+import com.sctk.cmc.auth.jwt.JwtProvider;
+import com.sctk.cmc.auth.service.SecurityUserDetailsService;
+import com.sctk.cmc.domain.Role;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final SecurityUserDetailsService securityUserDetailsService;
+
+    // 회원가입 외 모든 요청을 막아 놨는데, 얘가 문이 될거임. 여기서 권한을 부여
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("== JwtAuthenticationFilter ==");
+        String token = jwtProvider.resolveToken(request);
+        if (token != null && jwtProvider.isValidToken(token)) {
+            CommonUser user = jwtProvider.getPayload(token);
+
+            UserDetails userDetail;
+            if (user.getRole().equals(Role.MEMBER.getRoleName())) {
+                userDetail = securityUserDetailsService.loadMemberByUserEmail(user.getEmail());
+            }
+            else {
+                userDetail = securityUserDetailsService.loadDesignerByUserEmail(user.getEmail());
+            }
+
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                    new UsernamePasswordAuthenticationToken(userDetail, null, userDetail.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication( usernamePasswordAuthenticationToken );
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sctk/cmc/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/sctk/cmc/auth/jwt/JwtProvider.java
@@ -1,0 +1,122 @@
+package com.sctk.cmc.auth.jwt;
+
+import com.sctk.cmc.auth.domain.Token;
+import com.sctk.cmc.auth.dto.CommonUser;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
+
+@Component
+@Getter
+@RequiredArgsConstructor
+@Slf4j
+public class JwtProvider {
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String PREFIX_TOKEN = "Bearer ";
+
+    @Value("${jwt.token.secret-key}")
+    private String secretKey;
+    @Value("${jwt.token.access-token.expiredTimeMs}")
+    private Long accessTokenExpiredTimeMs;
+    @Value("${jwt.token.refresh-token.expiredTimeMs}")
+    private Long refreshTokenExpiredTimeMs;
+
+    public Token generateToken(CommonUser user) {
+        return Token.builder()
+                .accessToken( generateAccessToken(user) )
+                .refreshToken( generateRefreshToken() )
+                .build();
+    }
+
+    public String generateAccessToken(CommonUser user) {
+        Claims claims = Jwts.claims(); // 일종의 map.
+        claims.put("email", user.getEmail()); // 어떤 정보를 넣고 싶을 때, 이 claims 에 넣음
+
+        Date now = new Date();  // 생성 날짜
+        Date expired = new Date(now.getTime() + accessTokenExpiredTimeMs);   // 만료 날짜
+
+        return Jwts.builder()
+                .setClaims( claims )
+                .setAudience( user.getRole() )
+                .setSubject("access_token")
+                .setIssuedAt( now )
+                .setExpiration( expired )
+                .signWith( SignatureAlgorithm.HS256, secretKey ) // SignatureAlgorithm.HS256 를 이용해서 key를 암호화(sign) 함.
+                .compact();
+    }
+
+    public String generateRefreshToken() {
+        Claims claims = Jwts.claims();
+
+        Date now = new Date();
+        Date expired = new Date(now.getTime() + refreshTokenExpiredTimeMs);
+
+        return Jwts.builder()
+                .setClaims( claims )
+                .setSubject("refresh_token")
+                .setIssuedAt( now )
+                .setExpiration( expired )
+                .signWith( SignatureAlgorithm.HS256, secretKey )
+                .compact();
+    }
+
+    public boolean isValidToken(String token) {
+        try{
+            Jws<Claims> claimsJws = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+
+            log.info("expiredDate={}", claimsJws.getBody().getExpiration());
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            log.info("이미 만료된 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 토큰 형식입니다.");
+        } catch (MalformedJwtException e) {
+            log.info("인증 토큰이 올바르게 구성되지 않았습니다.");
+        } catch (SignatureException e) {
+            log.info("인증 시그니처가 올바르지 않습니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("잘못된 토큰입니다.");
+        }
+        return false;
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX_TOKEN)) {
+            return bearerToken.substring(PREFIX_TOKEN.length());
+        }
+        return null;
+    }
+
+    public CommonUser getPayload(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token).getBody();
+
+        return CommonUser.builder()
+                .role(claims.getAudience())
+                .email(claims.get("email", String.class))
+                .build();
+    }
+
+    public Date getExpiredTimeMs(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody().getExpiration();
+    }
+}
+

--- a/src/main/java/com/sctk/cmc/auth/jwt/JwtService.java
+++ b/src/main/java/com/sctk/cmc/auth/jwt/JwtService.java
@@ -1,0 +1,61 @@
+package com.sctk.cmc.auth.jwt;
+
+import com.sctk.cmc.auth.domain.Token;
+import com.sctk.cmc.auth.dto.CommonUser;
+import com.sctk.cmc.auth.dto.TokenReissueRequestDto;
+import com.sctk.cmc.auth.dto.TokenReissueResponseDto;
+import com.sctk.cmc.redis.domain.RedisDesigner;
+import com.sctk.cmc.redis.domain.RedisMember;
+import com.sctk.cmc.redis.service.RedisService;
+import com.sctk.cmc.common.exception.CMCException;
+import com.sctk.cmc.common.exception.ResponseStatus;
+import com.sctk.cmc.domain.Role;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.sctk.cmc.common.exception.ResponseStatus.INCONSISTENCY_REFRESH_TOKEN;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class JwtService {
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+
+
+    public TokenReissueResponseDto reissue(TokenReissueRequestDto requestDto) {
+        String oldAccessToken = requestDto.getAccessToken();
+        String oldRefreshToken = requestDto.getRefreshToken();
+        CommonUser user = jwtProvider.getPayload(oldAccessToken);
+
+        if (!validateRefreshToken(user, oldRefreshToken)) {
+            throw new CMCException(INCONSISTENCY_REFRESH_TOKEN);
+        }
+
+        Token newToken = jwtProvider.generateToken(user);
+
+        if (user.getRole().equals(Role.MEMBER.getRoleName())) {
+            redisService.saveMember(user.getEmail(), newToken.getRefreshToken());
+        }
+        else if (user.getRole().equals(Role.DESIGNER.getRoleName())) {
+            redisService.saveDesigner(user.getEmail(), newToken.getRefreshToken());
+        }
+
+        return TokenReissueResponseDto.of(newToken);
+    }
+
+    private boolean validateRefreshToken(CommonUser user, String oldRefreshToken) {
+        if (user.getRole().equals(Role.MEMBER.getRoleName())) {
+            RedisMember redisMember = redisService.getMember(user.getEmail());
+            String refreshTokenInRedis = redisMember.getRefreshToken();
+            return oldRefreshToken.equals(refreshTokenInRedis);
+        }
+        else if (user.getRole().equals(Role.DESIGNER.getRoleName())) {
+            RedisDesigner redisDesigner = redisService.getDesigner(user.getEmail());
+            String refreshTokenInRedis = redisDesigner.getRefreshToken();
+            return oldRefreshToken.equals(refreshTokenInRedis);
+        }
+        throw new CMCException(ResponseStatus.INVALID_ROLE);
+    }
+}

--- a/src/main/java/com/sctk/cmc/auth/service/SecurityUserDetailsService.java
+++ b/src/main/java/com/sctk/cmc/auth/service/SecurityUserDetailsService.java
@@ -1,0 +1,48 @@
+package com.sctk.cmc.auth.service;
+
+import com.sctk.cmc.auth.domain.SecurityDesignerDetails;
+import com.sctk.cmc.auth.domain.SecurityMemberDetails;
+import com.sctk.cmc.common.exception.CMCException;
+import com.sctk.cmc.domain.Designer;
+import com.sctk.cmc.domain.Member;
+import com.sctk.cmc.repository.DesignerRepository;
+import com.sctk.cmc.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.sctk.cmc.common.exception.ResponseStatus.MEMBERS_ILLEGAL_ID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class SecurityUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+    private final DesignerRepository designerRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return null;
+    }
+
+    public UserDetails loadMemberByUserEmail(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CMCException(MEMBERS_ILLEGAL_ID));
+
+        log.info("loadMemberByUserEmail, member=[{}][{}][{}]", member.getId(), member.getEmail(), member.getRole());
+        return new SecurityMemberDetails(member);
+    }
+
+    public UserDetails loadDesignerByUserEmail(String email) throws UsernameNotFoundException {
+        Designer designer = designerRepository.findByEmail(email)
+                .orElseThrow(() -> new CMCException(MEMBERS_ILLEGAL_ID));
+
+        log.info("loadDesignerByUserEmail, designer=[{}][{}][{}]", designer.getId(), designer.getEmail(), designer.getRole());
+        return new SecurityDesignerDetails(designer);
+    }
+}

--- a/src/main/java/com/sctk/cmc/controller/AuthController.java
+++ b/src/main/java/com/sctk/cmc/controller/AuthController.java
@@ -1,0 +1,75 @@
+package com.sctk.cmc.controller;
+
+import com.sctk.cmc.auth.dto.LoginResponseDto;
+import com.sctk.cmc.auth.dto.TokenReissueRequestDto;
+import com.sctk.cmc.auth.dto.TokenReissueResponseDto;
+import com.sctk.cmc.auth.jwt.JwtService;
+import com.sctk.cmc.common.response.BaseResponse;
+import com.sctk.cmc.dto.designer.DesignerJoinResponseDto;
+import com.sctk.cmc.dto.member.MemberJoinResponseDto;
+import com.sctk.cmc.dto.member.MemberLoginParam;
+import com.sctk.cmc.service.abstractions.AuthService;
+import com.sctk.cmc.service.abstractions.DesignerService;
+import com.sctk.cmc.service.abstractions.MemberService;
+import com.sctk.cmc.service.dto.designer.DesignerJoinParam;
+import com.sctk.cmc.service.dto.member.MemberJoinParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final MemberService memberService;
+    private final DesignerService designerService;
+    private final AuthService authService;
+    private final JwtService jwtService;
+
+    @PostMapping("/signup/member")
+    public BaseResponse<MemberJoinResponseDto> signupMember(@RequestBody MemberJoinParam param) {
+
+        Long memberId = memberService.join(param);
+        MemberJoinResponseDto responseDto = MemberJoinResponseDto.of(memberId);
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PostMapping("/signin/member")
+    public BaseResponse<LoginResponseDto> signinMember(@RequestBody MemberLoginParam param) {
+
+        LoginResponseDto responseDto = authService.loginMember(param.getEmail(), param.getPassword());
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PostMapping("/signup/designer")
+    public BaseResponse<DesignerJoinResponseDto> signupDesigner(@RequestBody DesignerJoinParam param) {
+
+        Long designerId = designerService.join(param);
+        DesignerJoinResponseDto responseDto = DesignerJoinResponseDto.of(designerId);
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PostMapping("/signin/designer")
+    public BaseResponse<LoginResponseDto> signinDesigner(@RequestBody DesignerJoinParam param) {
+
+        LoginResponseDto responseDto = authService.loginDesigner(param.getEmail(), param.getPassword());
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PostMapping("/token/reissuance")
+    public BaseResponse<TokenReissueResponseDto> tokenReissueMember(@RequestBody TokenReissueRequestDto requestDto) {
+
+        TokenReissueResponseDto responseDto = jwtService.reissue(requestDto);
+
+        return new BaseResponse<>(responseDto);
+    }
+}

--- a/src/main/java/com/sctk/cmc/domain/Role.java
+++ b/src/main/java/com/sctk/cmc/domain/Role.java
@@ -1,0 +1,13 @@
+package com.sctk.cmc.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+    MEMBER("ROLE_MEMBER"),
+    DESIGNER("ROLE_DESIGNER");
+
+    private final String roleName;
+}

--- a/src/main/java/com/sctk/cmc/dto/designer/DesignerJoinResponseDto.java
+++ b/src/main/java/com/sctk/cmc/dto/designer/DesignerJoinResponseDto.java
@@ -1,0 +1,16 @@
+package com.sctk.cmc.dto.designer;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DesignerJoinResponseDto {
+    private Long id;
+
+    public static DesignerJoinResponseDto of(Long memberId) {
+        return DesignerJoinResponseDto.builder()
+                .id(memberId)
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/dto/designer/DesignerLoginParam.java
+++ b/src/main/java/com/sctk/cmc/dto/designer/DesignerLoginParam.java
@@ -1,0 +1,11 @@
+package com.sctk.cmc.dto.designer;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DesignerLoginParam {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/sctk/cmc/dto/member/MemberJoinResponseDto.java
+++ b/src/main/java/com/sctk/cmc/dto/member/MemberJoinResponseDto.java
@@ -1,0 +1,16 @@
+package com.sctk.cmc.dto.member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberJoinResponseDto {
+    private Long id;
+
+    public static MemberJoinResponseDto of(Long memberId) {
+        return MemberJoinResponseDto.builder()
+                .id(memberId)
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/dto/member/MemberLoginParam.java
+++ b/src/main/java/com/sctk/cmc/dto/member/MemberLoginParam.java
@@ -1,0 +1,11 @@
+package com.sctk.cmc.dto.member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberLoginParam {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/sctk/cmc/redis/RedisConfig.java
+++ b/src/main/java/com/sctk/cmc/redis/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.sctk.cmc.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    // RedisConnectionFactory 인터페이스를 이용하여 redis 저장소에 연결
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+}

--- a/src/main/java/com/sctk/cmc/redis/domain/RedisDesigner.java
+++ b/src/main/java/com/sctk/cmc/redis/domain/RedisDesigner.java
@@ -1,0 +1,26 @@
+package com.sctk.cmc.redis.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@RedisHash("DESIGNER")
+public class RedisDesigner {
+    @Id
+    private String email;
+    private String refreshToken;
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expiredTimeMs;
+
+    @Builder
+    public RedisDesigner(String email, String refreshToken, Long expiredTimeMs) {
+        this.email = email;
+        this.refreshToken = refreshToken;
+        this.expiredTimeMs = expiredTimeMs;
+    }
+}

--- a/src/main/java/com/sctk/cmc/redis/domain/RedisMember.java
+++ b/src/main/java/com/sctk/cmc/redis/domain/RedisMember.java
@@ -1,0 +1,26 @@
+package com.sctk.cmc.redis.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@RedisHash("MEMBER")
+public class RedisMember {
+    @Id
+    private String email;
+    private String refreshToken;
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expiredTimeMs;
+
+    @Builder
+    public RedisMember(String email, String refreshToken, Long expiredTimeMs) {
+        this.email = email;
+        this.refreshToken = refreshToken;
+        this.expiredTimeMs = expiredTimeMs;
+    }
+}

--- a/src/main/java/com/sctk/cmc/redis/domain/RedisMember.java
+++ b/src/main/java/com/sctk/cmc/redis/domain/RedisMember.java
@@ -9,12 +9,12 @@ import org.springframework.data.redis.core.TimeToLive;
 import java.util.concurrent.TimeUnit;
 
 @Getter
-@RedisHash("MEMBER")
+@RedisHash("MEMBER") // prefix에 입력될 keyspace
 public class RedisMember {
-    @Id
+    @Id // keyspace:@Id 형태로 키를 저장함.
     private String email;
     private String refreshToken;
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    @TimeToLive(unit = TimeUnit.MILLISECONDS) // Redis 에 유지되는 시간
     private Long expiredTimeMs;
 
     @Builder

--- a/src/main/java/com/sctk/cmc/redis/repository/RedisDesignerRepository.java
+++ b/src/main/java/com/sctk/cmc/redis/repository/RedisDesignerRepository.java
@@ -1,0 +1,7 @@
+package com.sctk.cmc.redis.repository;
+
+import com.sctk.cmc.redis.domain.RedisDesigner;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisDesignerRepository extends CrudRepository<RedisDesigner, String> {
+}

--- a/src/main/java/com/sctk/cmc/redis/repository/RedisMemberRepository.java
+++ b/src/main/java/com/sctk/cmc/redis/repository/RedisMemberRepository.java
@@ -1,0 +1,7 @@
+package com.sctk.cmc.redis.repository;
+
+import com.sctk.cmc.redis.domain.RedisMember;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisMemberRepository extends CrudRepository<RedisMember, String> {
+}

--- a/src/main/java/com/sctk/cmc/redis/service/RedisService.java
+++ b/src/main/java/com/sctk/cmc/redis/service/RedisService.java
@@ -1,0 +1,67 @@
+package com.sctk.cmc.redis.service;
+
+import com.sctk.cmc.redis.domain.RedisDesigner;
+import com.sctk.cmc.redis.domain.RedisMember;
+import com.sctk.cmc.redis.repository.RedisDesignerRepository;
+import com.sctk.cmc.redis.repository.RedisMemberRepository;
+import com.sctk.cmc.common.exception.CMCException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.sctk.cmc.common.exception.ResponseStatus.AUTHENTICATION_ILLEGAL_EMAIL;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class RedisService {
+    private final RedisMemberRepository redisMemberRepository;
+    private final RedisDesignerRepository redisDesignerRepository;
+    @Value("${jwt.token.refresh-token.expiredTimeMs}")
+    private Long refreshTokenExpiredTimeMs;
+
+    @Transactional
+    public void saveMember(String email, String refreshToken){
+        RedisMember redisMember = RedisMember.builder()
+                .email(email)
+                .refreshToken(refreshToken)
+                .expiredTimeMs(refreshTokenExpiredTimeMs)
+                .build();
+
+        redisMemberRepository.save(redisMember);
+    }
+
+    @Transactional
+    public void saveDesigner(String email, String refreshToken ){
+        RedisDesigner redisDesigner = RedisDesigner.builder()
+                .email(email)
+                .refreshToken(refreshToken)
+                .expiredTimeMs(refreshTokenExpiredTimeMs)
+                .build();
+
+        redisDesignerRepository.save(redisDesigner);
+    }
+
+    public RedisMember getMember(String email){
+        return redisMemberRepository.findById(email)
+                .orElseThrow(() -> new CMCException(AUTHENTICATION_ILLEGAL_EMAIL));
+    }
+
+    public RedisDesigner getDesigner(String email){
+        return redisDesignerRepository.findById(email)
+                .orElseThrow(() -> new CMCException(AUTHENTICATION_ILLEGAL_EMAIL));
+    }
+
+    @Transactional
+    public void deleteMember(String email) {
+        redisMemberRepository.deleteById(email);
+    }
+
+    @Transactional
+    public void deleteDesigner(String email) {
+        redisDesignerRepository.deleteById(email);
+    }
+}

--- a/src/main/java/com/sctk/cmc/service/AuthServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/AuthServiceImpl.java
@@ -4,7 +4,7 @@ import com.sctk.cmc.auth.domain.Token;
 import com.sctk.cmc.auth.dto.CommonUser;
 import com.sctk.cmc.auth.dto.LoginResponseDto;
 import com.sctk.cmc.auth.jwt.JwtProvider;
-import com.sctk.cmc.auth.redis.RedisService;
+import com.sctk.cmc.redis.service.RedisService;
 import com.sctk.cmc.common.exception.CMCException;
 import com.sctk.cmc.common.exception.ResponseStatus;
 import com.sctk.cmc.domain.Designer;


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- Spring Security와 JWT를 통해 사용자 인증, 인가 기능을 구현하였습니다.
- JWT 를 캐쉬에 저장하기 위해 Redis 를 구현하였습니다.
- 회원가입 API 구현
- 로그인 API 구현
- 토큰 재발급 API 구현

### :: 특이사항
- Redis 설정 관련 notion 참고
- https://brook-cadmium-79c.notion.site/CMC-95cf952f813d4ece98cd331441b47fe1
