### PR TITLE
[Feat] Custom CRUD 및 디자이너용 승인, 거절 API 구현

### DIFF
--- a/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
+++ b/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
@@ -30,7 +30,10 @@ public enum ResponseStatus {
     INCONSISTENCY_REFRESH_TOKEN(4002, "Refresh Token 이 일치하지 않습니다."),
 
     // redis
-    INVALID_ROLE(4003, "잘못된 ROLE 입니다.");
+    INVALID_ROLE(4003, "잘못된 ROLE 입니다."),
+
+    // custom
+    CUSTOM_ILLEGAL_ID(5000, "존재 하지 않는 custom ID 입니다.");
 
 
     private int code;

--- a/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
+++ b/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
@@ -33,7 +33,8 @@ public enum ResponseStatus {
     INVALID_ROLE(4003, "잘못된 ROLE 입니다."),
 
     // custom
-    CUSTOM_ILLEGAL_ID(5000, "존재 하지 않는 custom ID 입니다.");
+    CUSTOM_ILLEGAL_ID(5000, "존재 하지 않는 custom ID 입니다."),
+    ALREADY_RESPONDED_CUSTOM(5001, "이미 응답한 custom 요청 입니다.");
 
 
     private int code;

--- a/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
+++ b/src/main/java/com/sctk/cmc/common/exception/ResponseStatus.java
@@ -22,6 +22,7 @@ public enum ResponseStatus {
     DESIGNERS_HIGH_CATEGORY_MORE_THAN_LIMIT(3002, "등록할 수 있는 카테고리는 최대 3개입니다."),
     DESIGNERS_LOW_CATEGORY_MORE_THAN_LIMIT(3003, "한 카테고리에 등록할 수 있는 소재는 최대 3개입니다."),
     DESIGNERS_NON_EXISTING_CRITERIA(3004, "디자이너 검색에 존재하지 않는 기준입니다."),
+    NOT_HAVE_DESIGNERS_AUTHORITY(3004, "디자이너 권한이 없습니다."),
 
     // jwt
     INVALID_TOKEN(4000, "잘못된 Token 입니다."),

--- a/src/main/java/com/sctk/cmc/config/SecurityConfig.java
+++ b/src/main/java/com/sctk/cmc/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .antMatchers("/swagger-ui/**").permitAll()
                 .antMatchers("/v3/api-docs/**").permitAll()
                 .antMatchers("/api/v1/auth/**").permitAll()
+                .antMatchers("/api/v1/custom/**").permitAll()
                 .anyRequest()
                 .authenticated()
                 .and()

--- a/src/main/java/com/sctk/cmc/domain/Custom.java
+++ b/src/main/java/com/sctk/cmc/domain/Custom.java
@@ -1,6 +1,6 @@
 package com.sctk.cmc.domain;
 
-import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.custom.CustomRegisterParams;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -58,15 +58,15 @@ public class Custom extends BaseTimeEntity {
         this.active = active;
     }
 
-    public static Custom create(Member member, Designer designer, CustomParams customParams) {
+    public static Custom create(Member member, Designer designer, CustomRegisterParams customRegisterParams) {
         return Custom.builder()
                 .member(member)
                 .designer(designer)
-                .highCategory(customParams.getHighCategory())
-                .lowCategory(customParams.getLowCategory())
-                .title(customParams.getTitle())
-                .desiredPrice(customParams.getDesiredPrice())
-                .requirement(customParams.getRequirement())
+                .highCategory(customRegisterParams.getHighCategory())
+                .lowCategory(customRegisterParams.getLowCategory())
+                .title(customRegisterParams.getTitle())
+                .desiredPrice(customRegisterParams.getDesiredPrice())
+                .requirement(customRegisterParams.getRequirement())
                 // 이미지 빠짐
                 .accepted(CustomStatus.REQUESTING)
                 .active(true)

--- a/src/main/java/com/sctk/cmc/domain/Custom.java
+++ b/src/main/java/com/sctk/cmc/domain/Custom.java
@@ -81,4 +81,8 @@ public class Custom extends BaseTimeEntity {
         // 이렇게 하는게 맞나..
         this.customResult = customResult;
     }
+
+    public void changeStatusTo(CustomStatus status) {
+        this.accepted = status;
+    }
 }

--- a/src/main/java/com/sctk/cmc/domain/Custom.java
+++ b/src/main/java/com/sctk/cmc/domain/Custom.java
@@ -76,4 +76,9 @@ public class Custom extends BaseTimeEntity {
     public void changeActiveToFalse() {
         this.active = false;
     }
+
+    public void addCustomResult(CustomResult customResult) {
+        // 이렇게 하는게 맞나..
+        this.customResult = customResult;
+    }
 }

--- a/src/main/java/com/sctk/cmc/domain/Custom.java
+++ b/src/main/java/com/sctk/cmc/domain/Custom.java
@@ -1,5 +1,6 @@
 package com.sctk.cmc.domain;
 
+import com.sctk.cmc.service.dto.custom.CustomParams;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,7 +43,8 @@ public class Custom extends BaseTimeEntity {
 
     @Builder
     public Custom(Member member, Designer designer, String highCategory, String lowCategory, String title,
-                  Integer desiredPrice, String requirement, CustomReference reference, CustomResult customResult) {
+                  Integer desiredPrice, String requirement, CustomReference reference, CustomResult customResult,
+                  CustomStatus accepted, Boolean active) {
         this.member = member;
         this.designer = designer;
         this.highCategory = highCategory;
@@ -52,8 +54,23 @@ public class Custom extends BaseTimeEntity {
         this.requirement = requirement;
         this.reference = reference;
         this.customResult = customResult;
-        this.accepted = CustomStatus.REQUESTING;
-        this.active = true;
+        this.accepted = accepted;
+        this.active = active;
+    }
+
+    public static Custom create(Member member, Designer designer, CustomParams customParams) {
+        return Custom.builder()
+                .member(member)
+                .designer(designer)
+                .highCategory(customParams.getHighCategory())
+                .lowCategory(customParams.getLowCategory())
+                .title(customParams.getTitle())
+                .desiredPrice(customParams.getDesiredPrice())
+                .requirement(customParams.getRequirement())
+                // 이미지 빠짐
+                .accepted(CustomStatus.REQUESTING)
+                .active(true)
+                .build();
     }
 
     public void changeActiveToFalse() {

--- a/src/main/java/com/sctk/cmc/domain/CustomResult.java
+++ b/src/main/java/com/sctk/cmc/domain/CustomResult.java
@@ -15,7 +15,7 @@ public class CustomResult extends BaseTimeEntity  {
     @Column(name = "custom_result_id")
     private Long id;
 
-    @OneToOne(mappedBy = "custom_result_id")
+    @OneToOne(mappedBy = "customResult")
     private Custom custom;
 
     private LocalDate expectStartDate;

--- a/src/main/java/com/sctk/cmc/domain/CustomResult.java
+++ b/src/main/java/com/sctk/cmc/domain/CustomResult.java
@@ -1,5 +1,8 @@
 package com.sctk.cmc.domain;
 
+import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +30,32 @@ public class CustomResult extends BaseTimeEntity  {
     @Column(columnDefinition = "TEXT")
     private String message;
 
+    @Builder
+    public CustomResult(Custom custom, LocalDate expectStartDate, LocalDate expectEndDate, int expectPrice, String message) {
+        this.custom = custom;
+        if (custom != null) {
+            custom.addCustomResult(this);
+        }
+        this.expectStartDate = expectStartDate;
+        this.expectEndDate = expectEndDate;
+        this.expectPrice = expectPrice;
+        this.message = message;
+    }
+
+    public static CustomResult ofAcceptance(Custom custom, CustomResultAcceptParams customResultAcceptParams) {
+        return CustomResult.builder()
+                .custom(custom)
+                .expectStartDate(customResultAcceptParams.getExpectStartDate())
+                .expectEndDate(customResultAcceptParams.getExpectEndDate())
+                .expectPrice(customResultAcceptParams.getExpectPrice())
+                .message(customResultAcceptParams.getMessage())
+                .build();
+    }
+
+    public static CustomResult ofRejection(Custom custom, CustomResultRejectParams customResultRejectParams) {
+        return CustomResult.builder()
+                .custom(custom)
+                .message(customResultRejectParams.getMessage())
+                .build();
+    }
 }

--- a/src/main/java/com/sctk/cmc/repository/CustomRepository.java
+++ b/src/main/java/com/sctk/cmc/repository/CustomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomRepository extends JpaRepository<Custom, Long> {
 
@@ -15,4 +16,11 @@ public interface CustomRepository extends JpaRepository<Custom, Long> {
             "where d.id= :designerId " +
             "and c.active= true ")
     List<Custom> findAllByDesignerId(@Param("designerId") Long designerId);
+
+    @Query("select c from Custom c " +
+            "join fetch c.member " +
+            "join c.designer " +
+            "where c.id= :customId " +
+            "and c.active= true ")
+    Optional<Custom> findWithMemberById(@Param("customId") Long customId);
 }

--- a/src/main/java/com/sctk/cmc/repository/CustomRepository.java
+++ b/src/main/java/com/sctk/cmc/repository/CustomRepository.java
@@ -2,6 +2,17 @@ package com.sctk.cmc.repository;
 
 import com.sctk.cmc.domain.Custom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CustomRepository extends JpaRepository<Custom, Long> {
+
+    @Query("select c from Custom c " +
+            "join fetch c.member " +
+            "join c.designer d " +
+            "where d.id= :designerId " +
+            "and c.active= true ")
+    List<Custom> findAllByDesignerId(@Param("designerId") Long designerId);
 }

--- a/src/main/java/com/sctk/cmc/repository/CustomRepository.java
+++ b/src/main/java/com/sctk/cmc/repository/CustomRepository.java
@@ -1,0 +1,7 @@
+package com.sctk.cmc.repository;
+
+import com.sctk.cmc.domain.Custom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomRepository extends JpaRepository<Custom, Long> {
+}

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -6,7 +6,7 @@ import com.sctk.cmc.repository.CustomRepository;
 import com.sctk.cmc.repository.DesignerRepository;
 import com.sctk.cmc.repository.MemberRepository;
 import com.sctk.cmc.service.abstractions.CustomService;
-import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.custom.CustomRegisterParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
 import com.sctk.cmc.web.dto.custom.CustomGetDetailResponse;
@@ -34,15 +34,15 @@ public class CustomServiceImpl implements CustomService {
     private final DesignerRepository designerRepository;
 
     @Override
-    public CustomIdResponse register(Long memberId, CustomParams customParams) {
+    public CustomIdResponse register(Long memberId, CustomRegisterParams customRegisterParams) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CMCException(MEMBERS_ILLEGAL_ID));
 
-        Designer designer = designerRepository.findById(customParams.getDesignerId())
+        Designer designer = designerRepository.findById(customRegisterParams.getDesignerId())
                 .orElseThrow(() -> new CMCException(DESIGNERS_ILLEGAL_ID));
 
-        Custom createdcCustom = Custom.create(member, designer, customParams);
+        Custom createdcCustom = Custom.create(member, designer, customRegisterParams);
 
         Custom saveCustom = customRepository.save(createdcCustom);
 

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -1,0 +1,58 @@
+package com.sctk.cmc.service;
+
+import com.sctk.cmc.service.abstractions.CustomService;
+import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
+import com.sctk.cmc.web.dto.custom.CustomGetDetailResponse;
+import com.sctk.cmc.web.dto.custom.CustomGetInfoResponse;
+import com.sctk.cmc.web.dto.custom.CustomIdResponse;
+import com.sctk.cmc.web.dto.custom.CustomResultIdResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class CustomServiceImpl implements CustomService {
+    @Override
+    public CustomIdResponse register(Long memberId, CustomParams customParams) {
+        return null;
+    }
+
+    @Override
+    public List<CustomGetInfoResponse> retrieveAllInfo(Long designerId) {
+        return null;
+    }
+
+    @Override
+    public CustomGetDetailResponse retrieveDetailById(Long designerId, Long customId) {
+        return null;
+    }
+
+    @Override
+    public CustomGetInfoResponse retrieveInfoById(Long designerId, Long customId) {
+        return null;
+    }
+
+    @Override
+    public CustomIdResponse deleteSoft(Long designerId, Long customId) {
+        return null;
+    }
+
+    @Override
+    public CustomResultIdResponse acceptCustom(Long designerId, Long customId, CustomResultAcceptParams customResultAcceptParams) {
+        return null;
+    }
+
+    @Override
+    public CustomResultIdResponse rejectCustom(Long designerId, Long customId, CustomResultRejectParams customResultRejectParams) {
+        return null;
+    }
+}

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -77,7 +77,14 @@ public class CustomServiceImpl implements CustomService {
 
     @Override
     public CustomGetInfoResponse retrieveInfoById(Long designerId, Long customId) {
-        return null;
+
+        Custom custom = customRepository.findWithMemberById(customId)
+                .orElseThrow(() -> new CMCException(CUSTOM_ILLEGAL_ID));
+
+        //해당 커스텀 요청이 로그인한 디자이너 소유인지 검증
+        validateDesignerAuthority(designerId, custom);
+
+        return CustomGetInfoResponse.of(custom);
     }
 
     @Override

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -87,9 +87,18 @@ public class CustomServiceImpl implements CustomService {
         return CustomGetInfoResponse.of(custom);
     }
 
+    @Transactional
     @Override
     public CustomIdResponse deleteSoft(Long designerId, Long customId) {
-        return null;
+
+        Custom custom = customRepository.findWithMemberById(customId)
+                .orElseThrow(() -> new CMCException(CUSTOM_ILLEGAL_ID));
+
+        validateDesignerAuthority(designerId, custom);
+
+        custom.changeActiveToFalse();
+
+        return CustomIdResponse.of(custom.getId());
     }
 
     @Override

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.sctk.cmc.common.exception.ResponseStatus.DESIGNERS_ILLEGAL_ID;
 import static com.sctk.cmc.common.exception.ResponseStatus.MEMBERS_ILLEGAL_ID;
@@ -53,7 +54,14 @@ public class CustomServiceImpl implements CustomService {
 
     @Override
     public List<CustomGetInfoResponse> retrieveAllInfo(Long designerId) {
-        return null;
+
+        List<Custom> allCustoms = customRepository.findAllByDesignerId(designerId);
+
+        List<CustomGetInfoResponse> responseList = allCustoms.stream()
+                .map(CustomGetInfoResponse::of)
+                .collect(Collectors.toList());
+
+        return responseList;
     }
 
     @Override

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -23,8 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.sctk.cmc.common.exception.ResponseStatus.DESIGNERS_ILLEGAL_ID;
-import static com.sctk.cmc.common.exception.ResponseStatus.MEMBERS_ILLEGAL_ID;
+import static com.sctk.cmc.common.exception.ResponseStatus.*;
 
 
 @Service
@@ -66,7 +65,14 @@ public class CustomServiceImpl implements CustomService {
 
     @Override
     public CustomGetDetailResponse retrieveDetailById(Long designerId, Long customId) {
-        return null;
+
+        Custom custom = customRepository.findWithMemberById(customId)
+                .orElseThrow(() -> new CMCException(CUSTOM_ILLEGAL_ID));
+
+        //해당 커스텀 요청이 로그인한 디자이너 소유인지 검증
+        validateDesignerAuthority(designerId, custom);
+
+        return CustomGetDetailResponse.of(custom);
     }
 
     @Override
@@ -88,4 +94,11 @@ public class CustomServiceImpl implements CustomService {
     public CustomResultIdResponse rejectCustom(Long designerId, Long customId, CustomResultRejectParams customResultRejectParams) {
         return null;
     }
+
+    private void validateDesignerAuthority(Long designerId, Custom custom) {
+        if ( !custom.getDesigner().getId().equals(designerId) ) {
+            throw new CMCException(NOT_HAVE_DESIGNERS_AUTHORITY);
+        }
+    }
+
 }

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -1,5 +1,12 @@
 package com.sctk.cmc.service;
 
+import com.sctk.cmc.common.exception.CMCException;
+import com.sctk.cmc.domain.Custom;
+import com.sctk.cmc.domain.Designer;
+import com.sctk.cmc.domain.Member;
+import com.sctk.cmc.repository.CustomRepository;
+import com.sctk.cmc.repository.DesignerRepository;
+import com.sctk.cmc.repository.MemberRepository;
 import com.sctk.cmc.service.abstractions.CustomService;
 import com.sctk.cmc.service.dto.custom.CustomParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
@@ -15,15 +22,33 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.sctk.cmc.common.exception.ResponseStatus.DESIGNERS_ILLEGAL_ID;
+import static com.sctk.cmc.common.exception.ResponseStatus.MEMBERS_ILLEGAL_ID;
+
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
 public class CustomServiceImpl implements CustomService {
+    private final CustomRepository customRepository;
+    private final MemberRepository memberRepository;
+    private final DesignerRepository designerRepository;
+
     @Override
     public CustomIdResponse register(Long memberId, CustomParams customParams) {
-        return null;
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CMCException(MEMBERS_ILLEGAL_ID));
+
+        Designer designer = designerRepository.findById(customParams.getDesignerId())
+                .orElseThrow(() -> new CMCException(DESIGNERS_ILLEGAL_ID));
+
+        Custom createdcCustom = Custom.create(member, designer, customParams);
+
+        Custom saveCustom = customRepository.save(createdcCustom);
+
+        return CustomIdResponse.of(saveCustom.getId());
     }
 
     @Override

--- a/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/CustomServiceImpl.java
@@ -118,9 +118,21 @@ public class CustomServiceImpl implements CustomService {
         return CustomResultIdResponse.of(custom.getId());
     }
 
+    @Transactional
     @Override
     public CustomResultIdResponse rejectCustom(Long designerId, Long customId, CustomResultRejectParams customResultRejectParams) {
-        return null;
+
+        Custom custom = customRepository.findWithMemberById(customId)
+                .orElseThrow(() -> new CMCException(CUSTOM_ILLEGAL_ID));
+
+        validateDesignerAuthority(designerId, custom);
+
+        validateAcceptedIsRequesting(custom);
+
+        CustomResult.ofRejection(custom, customResultRejectParams);
+        custom.changeStatusTo(CustomStatus.REFUSAL);
+
+        return CustomResultIdResponse.of(custom.getId());
     }
 
     private void validateDesignerAuthority(Long designerId, Custom custom) {

--- a/src/main/java/com/sctk/cmc/service/abstractions/CustomService.java
+++ b/src/main/java/com/sctk/cmc/service/abstractions/CustomService.java
@@ -1,6 +1,6 @@
 package com.sctk.cmc.service.abstractions;
 
-import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.custom.CustomRegisterParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
 import com.sctk.cmc.web.dto.custom.CustomGetDetailResponse;
@@ -11,7 +11,7 @@ import com.sctk.cmc.web.dto.custom.CustomResultIdResponse;
 import java.util.List;
 
 public interface CustomService {
-    CustomIdResponse register(Long memberId, CustomParams customParams);
+    CustomIdResponse register(Long memberId, CustomRegisterParams customRegisterParams);
 
     List<CustomGetInfoResponse> retrieveAllInfo(Long designerId);
 

--- a/src/main/java/com/sctk/cmc/service/abstractions/CustomService.java
+++ b/src/main/java/com/sctk/cmc/service/abstractions/CustomService.java
@@ -1,0 +1,27 @@
+package com.sctk.cmc.service.abstractions;
+
+import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
+import com.sctk.cmc.web.dto.custom.CustomGetDetailResponse;
+import com.sctk.cmc.web.dto.custom.CustomGetInfoResponse;
+import com.sctk.cmc.web.dto.custom.CustomIdResponse;
+import com.sctk.cmc.web.dto.custom.CustomResultIdResponse;
+
+import java.util.List;
+
+public interface CustomService {
+    CustomIdResponse register(Long memberId, CustomParams customParams);
+
+    List<CustomGetInfoResponse> retrieveAllInfo(Long designerId);
+
+    CustomGetDetailResponse retrieveDetailById(Long designerId, Long customId);
+
+    CustomGetInfoResponse retrieveInfoById(Long designerId, Long customId);
+
+    CustomIdResponse deleteSoft(Long designerId, Long customId);
+
+    CustomResultIdResponse acceptCustom(Long designerId, Long customId, CustomResultAcceptParams customResultAcceptParams);
+
+    CustomResultIdResponse rejectCustom(Long designerId, Long customId, CustomResultRejectParams customResultRejectParams);
+}

--- a/src/main/java/com/sctk/cmc/service/dto/custom/CustomParams.java
+++ b/src/main/java/com/sctk/cmc/service/dto/custom/CustomParams.java
@@ -1,0 +1,33 @@
+package com.sctk.cmc.service.dto.custom;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.*;
+
+@Getter
+@Builder
+public class CustomParams {
+    @NotBlank(message = "[request] 요청서 제목을 입력해 주세요.")
+    @Size(min = 2, max = 20, message = "[request] 요청서 제목은 2 - 20글자로 입력해 주세요.")
+    private String title;
+
+    @NotBlank(message = "[request] 대분류를 입력해 주세요")
+    private String highCategory;
+
+    @NotBlank(message = "[request] 소분류를 입력해 주세요")
+    private String lowCategory;
+
+    @NotNull(message = "[request] 희망 가격을 입력해 주세요")
+    @Positive // 양수만 가능
+    private int desiredPrice;
+
+    @Size(max = 50, message = "[request] 요청 사항은 최대 50글자 입니다.")
+    private String requirement;
+
+    // 이미지 빠짐
+
+    @NotNull(message = "[request] 디자이너를 선택해 주세요.")
+    @Positive
+    private Long designerId;
+}

--- a/src/main/java/com/sctk/cmc/service/dto/custom/CustomRegisterParams.java
+++ b/src/main/java/com/sctk/cmc/service/dto/custom/CustomRegisterParams.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.*;
 
 @Getter
 @Builder
-public class CustomParams {
+public class CustomRegisterParams {
     @NotBlank(message = "[request] 요청서 제목을 입력해 주세요.")
     @Size(min = 2, max = 20, message = "[request] 요청서 제목은 2 - 20글자로 입력해 주세요.")
     private String title;

--- a/src/main/java/com/sctk/cmc/service/dto/customResult/CustomResultAcceptParams.java
+++ b/src/main/java/com/sctk/cmc/service/dto/customResult/CustomResultAcceptParams.java
@@ -1,0 +1,25 @@
+package com.sctk.cmc.service.dto.customResult;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.time.LocalDate;
+
+@Getter
+public class CustomResultAcceptParams {
+    @NotNull(message = "[request] 예상 시작 날짜를 입력해주세요.")
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate expectStartDate;
+
+    @NotNull(message = "[request] 예상 마감 날짜를 입력해주세요.")
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate expectEndDate;
+
+    @NotNull(message = "[request] 확정된 가격을 입력해 주세요")
+    @Positive
+    private int expectPrice;
+
+    private String message;
+}

--- a/src/main/java/com/sctk/cmc/service/dto/customResult/CustomResultRejectParams.java
+++ b/src/main/java/com/sctk/cmc/service/dto/customResult/CustomResultRejectParams.java
@@ -1,0 +1,13 @@
+package com.sctk.cmc.service.dto.customResult;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+public class CustomResultRejectParams {
+    @NotBlank(message = "[request] 거절 사유를 입력해 주세요")
+    @Size(max = 50, message = "[request] 50글자 이하로 입력해주세요.")
+    private String message;
+}

--- a/src/main/java/com/sctk/cmc/web/controller/CustomController.java
+++ b/src/main/java/com/sctk/cmc/web/controller/CustomController.java
@@ -4,7 +4,7 @@ import com.sctk.cmc.auth.domain.SecurityDesignerDetails;
 import com.sctk.cmc.auth.domain.SecurityMemberDetails;
 import com.sctk.cmc.common.response.BaseResponse;
 import com.sctk.cmc.service.abstractions.CustomService;
-import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.custom.CustomRegisterParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
 import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
 import com.sctk.cmc.web.dto.custom.CustomGetDetailResponse;
@@ -31,10 +31,10 @@ public class CustomController {
     @PostMapping("/custom")
     @Operation(summary = "커스텀 요청 생성 API", description = "디자이너에게 커스텀 제작 요청을 생성합니다.")
     public BaseResponse<CustomIdResponse> register(@AuthenticationPrincipal SecurityMemberDetails memberDetails,
-                                                   @Valid @RequestBody CustomParams customParams) {
+                                                   @Valid @RequestBody CustomRegisterParams customRegisterParams) {
 
         Long memberId = memberDetails.getId();
-        CustomIdResponse response = customService.register(memberId, customParams);
+        CustomIdResponse response = customService.register(memberId, customRegisterParams);
 
         return new BaseResponse<>(response);
     }

--- a/src/main/java/com/sctk/cmc/web/controller/CustomController.java
+++ b/src/main/java/com/sctk/cmc/web/controller/CustomController.java
@@ -1,0 +1,109 @@
+package com.sctk.cmc.web.controller;
+
+import com.sctk.cmc.auth.domain.SecurityDesignerDetails;
+import com.sctk.cmc.auth.domain.SecurityMemberDetails;
+import com.sctk.cmc.common.response.BaseResponse;
+import com.sctk.cmc.service.abstractions.CustomService;
+import com.sctk.cmc.service.dto.custom.CustomParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultAcceptParams;
+import com.sctk.cmc.service.dto.customResult.CustomResultRejectParams;
+import com.sctk.cmc.web.dto.custom.CustomGetDetailResponse;
+import com.sctk.cmc.web.dto.custom.CustomGetInfoResponse;
+import com.sctk.cmc.web.dto.custom.CustomIdResponse;
+import com.sctk.cmc.web.dto.custom.CustomResultIdResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Custom", description = "커스텀 API Document")
+public class CustomController {
+
+    private final CustomService customService;
+
+    @PostMapping("/custom")
+    @Operation(summary = "커스텀 요청 생성 API", description = "디자이너에게 커스텀 제작 요청을 생성합니다.")
+    public BaseResponse<CustomIdResponse> register(@AuthenticationPrincipal SecurityMemberDetails memberDetails,
+                                                   @Valid @RequestBody CustomParams customParams) {
+
+        Long memberId = memberDetails.getId();
+        CustomIdResponse response = customService.register(memberId, customParams);
+
+        return new BaseResponse<>(response);
+    }
+
+    @GetMapping("/custom")
+    @Operation(summary = "커스텀 요청 전체 간단 조회 API", description = "디자이너가 모든 커스텀 요청을 간단 조회할 때 사용합니다.")
+    public BaseResponse<List<CustomGetInfoResponse>> retrieveAllInfo(@AuthenticationPrincipal SecurityDesignerDetails designerDetails) {
+
+        Long designerId = designerDetails.getId();
+        List<CustomGetInfoResponse> responseList = customService.retrieveAllInfo(designerId);
+
+        return new BaseResponse<>(responseList);
+    }
+
+    @GetMapping("/custom/{customId}/detail")
+    @Operation(summary = "커스텀 요청 상세 조회 API", description = "디자이너가 커스텀 요청을 상세 조회할 때 사용합니다.")
+    public BaseResponse<CustomGetDetailResponse> retrieveDetail(@AuthenticationPrincipal SecurityDesignerDetails designerDetails,
+                                                                @PathVariable("customId") Long customId) {
+
+        Long designerId = designerDetails.getId();
+        CustomGetDetailResponse response = customService.retrieveDetailById(designerId, customId);
+
+        return new BaseResponse<>(response);
+    }
+
+    //필요 없나?
+    @GetMapping("/custom/{customId}/info")
+    @Operation(summary = "커스텀 요청 간단 조회 API", description = "디자이너가 커스텀 요청을 간단 조회할 때 사용합니다.")
+    public BaseResponse<CustomGetInfoResponse> retrieveInfo(@AuthenticationPrincipal SecurityDesignerDetails designerDetails,
+                                                            @PathVariable("customId") Long customId) {
+
+        Long designerId = designerDetails.getId();
+        CustomGetInfoResponse response = customService.retrieveInfoById(designerId, customId);
+
+        return new BaseResponse<>(response);
+    }
+
+    @DeleteMapping("/custom/{customId}")
+    @Operation(summary = "커스텀 요청 삭제(soft) API", description = "디자이너가 커스텀 요청을 수락 또는 거절하면 삭제합니다.")
+    public BaseResponse<CustomIdResponse> deleteSoft(@AuthenticationPrincipal SecurityDesignerDetails designerDetails,
+                                                     @PathVariable("customId") Long customId) {
+
+        Long designerId = designerDetails.getId();
+        CustomIdResponse response = customService.deleteSoft(designerId, customId);
+
+        return new BaseResponse<>(response);
+    }
+
+    @PostMapping("/custom/{customId}/acceptance")
+    @Operation(summary = "커스텀 요청 수락 API", description = "디자이너가 커스텀 요청을 수락합니다.")
+    public BaseResponse<CustomResultIdResponse> acceptCustom(@AuthenticationPrincipal SecurityDesignerDetails designerDetails,
+                                                             @PathVariable("customId") Long customId,
+                                                             @Valid @RequestBody CustomResultAcceptParams customResultAcceptParams) {
+
+        Long designerId = designerDetails.getId();
+        CustomResultIdResponse response = customService.acceptCustom(designerId, customId, customResultAcceptParams);
+
+        return new BaseResponse<>(response);
+    }
+
+    @PostMapping("/custom/{customId}/rejection")
+    @Operation(summary = "커스텀 요청 거절 API", description = "디자이너가 커스텀 요청을 거절 합니다.")
+    public BaseResponse<CustomResultIdResponse> rejectCustom(@AuthenticationPrincipal SecurityDesignerDetails designerDetails,
+                                                             @PathVariable("customId") Long customId,
+                                                             @Valid @RequestBody CustomResultRejectParams customResultRejectParams) {
+
+        Long designerId = designerDetails.getId();
+        CustomResultIdResponse response = customService.rejectCustom(designerId, customId, customResultRejectParams);
+
+        return new BaseResponse<>(response);
+    }
+}

--- a/src/main/java/com/sctk/cmc/web/dto/custom/CustomGetDetailResponse.java
+++ b/src/main/java/com/sctk/cmc/web/dto/custom/CustomGetDetailResponse.java
@@ -1,0 +1,37 @@
+package com.sctk.cmc.web.dto.custom;
+
+import com.sctk.cmc.domain.Custom;
+import com.sctk.cmc.domain.CustomStatus;
+import com.sctk.cmc.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CustomGetDetailResponse {
+    private String title;
+    private Long memberId;
+    private String memberName;
+    private String memberProfileImgUrl;
+    private String highCategory;
+    private String lowCategory;
+    private Integer desiredPrice;
+    private String requirement;
+    private CustomStatus accepted;
+
+    public static CustomGetDetailResponse of(Custom custom) {
+        Member member = custom.getMember();
+
+        return CustomGetDetailResponse.builder()
+                .title(custom.getTitle())
+                .memberId(member.getId())
+                .memberName(member.getName())
+                .memberProfileImgUrl(member.getProfileImgUrl())
+                .highCategory(custom.getHighCategory())
+                .lowCategory(custom.getLowCategory())
+                .desiredPrice(custom.getDesiredPrice())
+                .requirement(custom.getRequirement())
+                .accepted(custom.getAccepted())
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/web/dto/custom/CustomGetInfoResponse.java
+++ b/src/main/java/com/sctk/cmc/web/dto/custom/CustomGetInfoResponse.java
@@ -1,0 +1,31 @@
+package com.sctk.cmc.web.dto.custom;
+
+import com.sctk.cmc.domain.Custom;
+import com.sctk.cmc.domain.CustomStatus;
+import com.sctk.cmc.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CustomGetInfoResponse {
+    private String title;
+    private Long memberId;
+    private String memberName;
+    private String memberProfileImgUrl;
+    private Integer desiredPrice;
+    private CustomStatus accepted;
+
+    public static CustomGetInfoResponse of(Custom custom) {
+        Member member = custom.getMember();
+
+        return CustomGetInfoResponse.builder()
+                .title(custom.getTitle())
+                .memberId(member.getId())
+                .memberName(member.getName())
+                .memberProfileImgUrl(member.getProfileImgUrl())
+                .desiredPrice(custom.getDesiredPrice())
+                .accepted(custom.getAccepted())
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/web/dto/custom/CustomIdResponse.java
+++ b/src/main/java/com/sctk/cmc/web/dto/custom/CustomIdResponse.java
@@ -1,0 +1,16 @@
+package com.sctk.cmc.web.dto.custom;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CustomIdResponse {
+    private Long customId;
+
+    public static CustomIdResponse of(Long customId) {
+        return CustomIdResponse.builder()
+                .customId(customId)
+                .build();
+    }
+}

--- a/src/main/java/com/sctk/cmc/web/dto/custom/CustomResultIdResponse.java
+++ b/src/main/java/com/sctk/cmc/web/dto/custom/CustomResultIdResponse.java
@@ -1,0 +1,16 @@
+package com.sctk.cmc.web.dto.custom;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CustomResultIdResponse {
+    private Long customResultId;
+
+    public static CustomResultIdResponse of(Long customResultId) {
+        return CustomResultIdResponse.builder()
+                .customResultId(customResultId)
+                .build();
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
### 🔥 다음과 같은 기능을 구현하였습니다.
- (구매자용) Custom 요청 등록 API
- (디자이너용) Custom 전체 조회 API
- (디자이너용) Custom 개별 상세정보 조회 API
- (디자이너용) Custom 개별 간단정보 조회 API
- (디자이너용) Custom 삭제 API
- (디자이너용) Custom 요청 승인 API
- (디자이너용) Custom 요청 거절 API

### :: 특이사항
### 🔥 CustomDto
- 요청 Dto 는 잘못된 데이터 저장을 방지하기 위해 Validation 을 추가하였습니다.
- 클라이언트로 부터 받는 요청 Dto 는 `엔티티명 + 행위 + Params` 로 명명 하였습니다.
- 클라이언트에게 응답하는 Dto 는 `엔티티명 + HTTP Method + 정보 + Response` 로 명명 하였습니다.
- 대부분 ServiceImpl 단에서 Dto를 생성하여 Controller 에게 넘겨주도록 구현하였습니다.

### 🔥 CustomController
- 대부분 ServiceImpl 로 부터 받은 ResponseDto를 BaseResponse<>() 에 담아 응답하도록 구현하였습니다.

### 🔥 CustomServiceImpl
- 해당 Custom 이 사용하고 있는 디자이너 본인의 것인지 검증하는 검증 메소드를 내부에 private 으로 선언하였습니다.
- Custom 에 대한 중복 승인, 거절을 방지하고자, 해당 Custom의 상태가 `REQUESTING` 인지 검증하는 검증 메소드를 내부에 private 으로 선언하였습니다.

### 🔥 CustomRepository
- Spring Data JPA 를 활용하였습니다.
- 기본적으로 모든 Custom 은 active =true 즉, 삭제되지 않은 Custom 만 조회하도록 하였습니다.

### ⚠️ 수정사항
- CustomResult 엔티티의 Custom에 대한 mappedBy가 잘못돼 있어 customResult 로 수정하였습니다.
- 구매자용 API 와 디자이너용 API 가 섞여있어, 추후에 리펙토링이 필요해 보입니다.
