### PR TITLE
디자이너 검색 기능 구현

### DIFF
--- a/src/main/java/com/sctk/cmc/common/config/SecurityConfig.java
+++ b/src/main/java/com/sctk/cmc/common/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 .antMatchers("/api/v1/designers/**/categories/**").hasAnyRole("MEMBER", "DESIGNER")
                 .antMatchers("/api/v1/designers/**/info/**").hasAnyRole("MEMBER", "DESIGNER")
                 .antMatchers("/api/v1/designers/**/profiles/**").hasAnyRole("MEMBER", "DESIGNER")
+                .antMatchers("/api/v1/designers/**/search/**").hasAnyRole("MEMBER", "DESIGNER")
                 .antMatchers("/api/v1/designers/**").hasRole("DESIGNER")
 
                 .antMatchers("/swagger-ui/**").permitAll()

--- a/src/main/java/com/sctk/cmc/controller/common/product/ProductController.java
+++ b/src/main/java/com/sctk/cmc/controller/common/product/ProductController.java
@@ -39,7 +39,7 @@ public class ProductController {
         return new BaseResponse<>(responses);
     }
 
-    @Operation(summary = "검색어(이름 or 태그)를 통한 상품 조회 API", description = "이름 or 태그에 검색어를 포함하는 상품을 조회합니다.")
+    @Operation(summary = "검색어(이름 or 태그)를 통한 상품 조회 API", description = "이름 or 태그에 검색어를 포함하는 상품을 조회합니다. Like Count 내림차순")
     @GetMapping("/search")
     public BaseResponse<List<ProductGetBySearchingResponse>> getSearchedProducts(@RequestParam String keyword) {
         List<ProductGetBySearchingResponse> responses = productService.searchAllByKeywordInNameAndTag(keyword);

--- a/src/main/java/com/sctk/cmc/controller/designer/DesignerController.java
+++ b/src/main/java/com/sctk/cmc/controller/designer/DesignerController.java
@@ -140,6 +140,15 @@ public class DesignerController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(
+            summary = "검색어([이름 / 닉네임] or [소재 / 카테고리])를 통한 디자이너 조회 API",
+            description = "[이름 / 닉네임] or [소재 / 카테고리]에 검색어를 포함하는 디자이너를 조회합니다. Like Count 내림차순")
+    @GetMapping("/search")
+    public BaseResponse<List<DesignerGetBySearchingResponse>> getSearchedDesigners(@RequestParam String keyword) {
+        List<DesignerGetBySearchingResponse> responses = designerService.searchAllByKeywordInNamesAndCategories(keyword);
+
+        return new BaseResponse<>(responses);
+    }
     private Long getDesignerId() {
 
         SecurityDesignerDetails designerDetails = (SecurityDesignerDetails) SecurityContextHolder.getContext()

--- a/src/main/java/com/sctk/cmc/controller/designer/dto/DesignerGetBySearchingResponse.java
+++ b/src/main/java/com/sctk/cmc/controller/designer/dto/DesignerGetBySearchingResponse.java
@@ -1,0 +1,11 @@
+package com.sctk.cmc.controller.designer.dto;
+
+import com.sctk.cmc.service.designer.dto.DesignerInfoCard;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DesignerGetBySearchingResponse {
+    private DesignerInfoCard designerInfoCard;
+}

--- a/src/main/java/com/sctk/cmc/domain/Designer.java
+++ b/src/main/java/com/sctk/cmc/domain/Designer.java
@@ -113,4 +113,12 @@ public class Designer extends BaseTimeEntity implements LikedEntity {
         highCategories.clear();
         lowCategories.clear();
     }
+
+    public boolean containsNameInCategories(String name) {
+        return highCategories.stream()
+                .anyMatch(highCategory -> highCategory.getName().toUpperCase().contains(name))
+                ||
+                lowCategories.stream()
+                .anyMatch(lowCategory -> lowCategory.getName().toUpperCase().contains(name));
+    }
 }

--- a/src/main/java/com/sctk/cmc/repository/designer/DesignerRepository.java
+++ b/src/main/java/com/sctk/cmc/repository/designer/DesignerRepository.java
@@ -26,6 +26,11 @@ public class DesignerRepository {
         return Optional.ofNullable(em.find(Designer.class, id));
     }
 
+    public List<Designer> findAll() {
+        return em.createQuery("select d from Designer d", Designer.class)
+                .getResultList();
+    }
+
     public List<Designer> findAllByName(String name) {
         return em.createQuery("select d from Designer d where d.name = :name", Designer.class)
                 .setParameter("name", name)

--- a/src/main/java/com/sctk/cmc/service/common/product/ProductServiceImpl.java
+++ b/src/main/java/com/sctk/cmc/service/common/product/ProductServiceImpl.java
@@ -73,15 +73,15 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<ProductGetBySearchingResponse> searchAllByKeywordInNameAndTag(String keyword) {
-        String upperKeyWord = keyword.toUpperCase();
+        String upperKeyword = keyword.toUpperCase();
 
-        if (upperKeyWord.length() < 2) {
+        if (upperKeyword.length() < 2) {
             throw new CMCException(SEARCH_KEYWORD_LENGTH_TOO_SHORT);
         }
         return productRepository.findAll()
                 .stream()
-                .filter(product -> product.getName().toUpperCase().contains(upperKeyWord)
-                        || product.getTag().toUpperCase().contains(upperKeyWord))
+                .filter(product -> product.getName().toUpperCase().contains(upperKeyword)
+                        || product.getTag().toUpperCase().contains(upperKeyword))
                 .map(product -> {
                     Designer designer = product.getDesigner();
                     return new ProductGetBySearchingResponse(

--- a/src/main/java/com/sctk/cmc/service/designer/DesignerService.java
+++ b/src/main/java/com/sctk/cmc/service/designer/DesignerService.java
@@ -1,14 +1,11 @@
 package com.sctk.cmc.service.designer;
 
+import com.sctk.cmc.controller.designer.dto.*;
 import com.sctk.cmc.domain.Designer;
-import com.sctk.cmc.controller.designer.dto.CategoryParam;
-import com.sctk.cmc.controller.designer.dto.CategoryView;
 import com.sctk.cmc.service.designer.dto.FilteredDesignerInfo;
 import com.sctk.cmc.service.designer.dto.DesignerInfo;
 import com.sctk.cmc.service.designer.dto.DesignerJoinParam;
 import com.sctk.cmc.controller.common.dto.ProfileImgPostResponse;
-import com.sctk.cmc.controller.designer.dto.PortfolioImgGetResponse;
-import com.sctk.cmc.controller.designer.dto.PortfolioImgPostResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -50,4 +47,6 @@ public interface DesignerService {
     PortfolioImgGetResponse retrieveAllOwnPortfolioImgById(Long designerId);
 
     void modifyCategories(Long designerId, List<CategoryParam> categoryParams);
+
+    List<DesignerGetBySearchingResponse> searchAllByKeywordInNamesAndCategories(String keyword);
 }


### PR DESCRIPTION
# 디자이너 검색 범위
- 이름
- 닉네임
- 카테고리 이름
- 소재 이름

위 4가지의 String이 keyword를 contain하는 경우에 디자이너를 반환하도록 하였습니다.

# 디자이너 DTO
보여지는 디자이너 정보는
DesignerInfoCard와 동일하기에
```java
public class DesignerGetBySearchingResponse {
    private DesignerInfoCard designerInfoCard;
}
```
위처럼 구현하였습니다.

# 전달 사항
모든 검색은 `LikeCount` 내림차순입니다.